### PR TITLE
Pass through a few of the new pluginOptions added to gatsby-theme-brain

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -2,9 +2,13 @@ const path = require("path");
 
 module.exports = ({
   notesDirectory = "content/",
+  notesFileExtensions = [".md", ".mdx"],
   noteTemplate = path.join(__dirname, "src/templates/note.js"),
+  additionalNoteTypes = {},
   rootPath = "/",
   rootNote = "about",
+  linkifyHashtags = false,
+  hideDoubleBrackets = false,
   mdxOtherwiseConfigured = false,
 }) => ({
   plugins: [
@@ -12,9 +16,13 @@ module.exports = ({
       resolve: "@aengusm/gatsby-theme-brain",
       options: {
         notesDirectory,
+        notesFileExtensions,
+        noteTemplate,
+        additionalNoteTypes,
         rootPath,
         rootNote,
-        noteTemplate,
+        linkifyHashtags,
+        hideDoubleBrackets,
         mdxOtherwiseConfigured,
       },
     },


### PR DESCRIPTION
I have added some functionality recently to gatsby-theme-brain that might be useful here. This PR passes through the parameters to enable that support

A couple of things:
- You can now limit to only a certain set of file types to be processed
- You can declare additional note types and a corresponding template to render some notes differently
- Hashtags can be linkified, so #Books could turn into a link to a Books page
- You can now hide the square brackets from those links. It will turn `[[Books]]` into `[Books](bookspageurl)`