### PR TITLE
Preserve ⌘ + click to open in new tabs

### DIFF
--- a/src/components/BrainNoteContainer.js
+++ b/src/components/BrainNoteContainer.js
@@ -2,7 +2,6 @@
 import React from 'react';
 import {
   useStackedPagesProvider,
-  LinkToStacked,
   StackedPagesProvider,
   PageIndexProvider,
 } from 'react-stacked-pages-hook';
@@ -12,6 +11,7 @@ import { Styled, jsx, Flex, Box } from 'theme-ui';
 import useWindowWidth from '../utils/useWindowWidth';
 import Header from './Header';
 import BrainNote from './BrainNote';
+import { LinkToStacked } from './CustomLinkToStacked';
 
 const NOTE_WIDTH = 576; // w-xl
 

--- a/src/components/CustomLinkToStacked.js
+++ b/src/components/CustomLinkToStacked.js
@@ -1,0 +1,83 @@
+import React, { useCallback  } from "react";
+import { GatsbyLinkProps, Link  } from "gatsby";
+import { useStackedPage } from "react-stacked-pages-hook";
+
+export const LinkToStacked = React.forwardRef(
+	(
+		{
+			to,
+			onClick,
+			onMouseLeave,
+			onMouseEnter,
+			...restProps
+
+		},
+		ref
+	) => {
+		const [
+			,
+			,
+			,
+			navigateToStackedPage,
+			highlightStackedPage,
+		] = useStackedPage();
+		const onClickHandler = useCallback(
+			(ev) => {
+				ev.preventDefault();
+				if (onClick)
+					onClick(ev);
+
+				const isMac = window.navigator.platform.toUpperCase().indexOf('MAC') >= 0;
+
+				/* Override command + click on MacOS and Ctrl + click on other OS */
+				if (isMac && ev.metaKey || !isMac && ev.ctrlKey)
+					window.open(to, '_blank');
+				else
+					navigateToStackedPage(to);
+
+			},
+			[navigateToStackedPage, to, onClick]
+
+		);
+
+		const onMouseEnterHandler = useCallback(
+			(ev) => {
+				highlightStackedPage(to, true);
+				if (onMouseEnter) {
+					onMouseEnter(ev);
+
+				}
+
+			},
+			[to, onMouseEnter, highlightStackedPage]
+
+		);
+
+		const onMouseLeaveHandler = useCallback(
+			(ev) => {
+				highlightStackedPage(to, false);
+				if (onMouseLeave) {
+					onMouseLeave(ev);
+
+				}
+
+			},
+			[to, onMouseLeave, highlightStackedPage]
+
+		);
+
+		return (
+			<Link
+				{...restProps}
+				to={to}
+				ref={ref}
+				onClick={onClickHandler}
+				onMouseEnter={onMouseEnterHandler}
+				onMouseLeave={onMouseLeaveHandler}
+			/>
+
+		);
+
+	}
+
+);

--- a/src/components/CustomLinkToStacked.js
+++ b/src/components/CustomLinkToStacked.js
@@ -3,81 +3,81 @@ import { GatsbyLinkProps, Link  } from "gatsby";
 import { useStackedPage } from "react-stacked-pages-hook";
 
 export const LinkToStacked = React.forwardRef(
-	(
-		{
-			to,
-			onClick,
-			onMouseLeave,
-			onMouseEnter,
-			...restProps
+  (
+    {
+      to,
+      onClick,
+      onMouseLeave,
+      onMouseEnter,
+      ...restProps
 
-		},
-		ref
-	) => {
-		const [
-			,
-			,
-			,
-			navigateToStackedPage,
-			highlightStackedPage,
-		] = useStackedPage();
-		const onClickHandler = useCallback(
-			(ev) => {
-				ev.preventDefault();
-				if (onClick)
-					onClick(ev);
+    },
+    ref
+  ) => {
+    const [
+      ,
+      ,
+      ,
+      navigateToStackedPage,
+      highlightStackedPage,
+    ] = useStackedPage();
+    const onClickHandler = useCallback(
+      (ev) => {
+        ev.preventDefault();
+        if (onClick)
+          onClick(ev);
 
-				const isMac = window.navigator.platform.toUpperCase().indexOf('MAC') >= 0;
+        const isMac = window.navigator.platform.toUpperCase().indexOf('MAC') >= 0;
 
-				/* Override command + click on MacOS and Ctrl + click on other OS */
-				if (isMac && ev.metaKey || !isMac && ev.ctrlKey)
-					window.open(to, '_blank');
-				else
-					navigateToStackedPage(to);
+        /* Override command + click on MacOS and Ctrl + click on other OS */
+        if (isMac && ev.metaKey || !isMac && ev.ctrlKey)
+          window.open(to, '_blank');
+        else
+          navigateToStackedPage(to);
 
-			},
-			[navigateToStackedPage, to, onClick]
+      },
+      [navigateToStackedPage, to, onClick]
 
-		);
+    );
 
-		const onMouseEnterHandler = useCallback(
-			(ev) => {
-				highlightStackedPage(to, true);
-				if (onMouseEnter) {
-					onMouseEnter(ev);
+    const onMouseEnterHandler = useCallback(
+      (ev) => {
+        highlightStackedPage(to, true);
+        if (onMouseEnter) {
+          onMouseEnter(ev);
 
-				}
+        }
 
-			},
-			[to, onMouseEnter, highlightStackedPage]
+      },
+      [to, onMouseEnter, highlightStackedPage]
 
-		);
+    );
 
-		const onMouseLeaveHandler = useCallback(
-			(ev) => {
-				highlightStackedPage(to, false);
-				if (onMouseLeave) {
-					onMouseLeave(ev);
+    const onMouseLeaveHandler = useCallback(
+      (ev) => {
+        highlightStackedPage(to, false);
+        if (onMouseLeave) {
+          onMouseLeave(ev);
 
-				}
+        }
 
-			},
-			[to, onMouseLeave, highlightStackedPage]
+      },
+      [to, onMouseLeave, highlightStackedPage]
 
-		);
+    );
 
-		return (
-			<Link
-				{...restProps}
-				to={to}
-				ref={ref}
-				onClick={onClickHandler}
-				onMouseEnter={onMouseEnterHandler}
-				onMouseLeave={onMouseLeaveHandler}
-			/>
+    return (
+      <Link
+        {...restProps}
+        to={to}
+        ref={ref}
+        onClick={onClickHandler}
+        onMouseEnter={onMouseEnterHandler}
+        onMouseLeave={onMouseLeaveHandler}
+      />
 
-		);
+    );
 
-	}
+  }
 
 );

--- a/src/components/MdxComponents.js
+++ b/src/components/MdxComponents.js
@@ -1,6 +1,6 @@
 /** @jsx jsx */
 import React from 'react';
-import { LinkToStacked } from 'react-stacked-pages-hook';
+import { LinkToStacked } from './CustomLinkToStacked';
 import { Link } from 'gatsby';
 import { jsx } from 'theme-ui';
 

--- a/src/components/ReferredBlock.js
+++ b/src/components/ReferredBlock.js
@@ -1,6 +1,6 @@
 /** @jsx jsx */
 import React from 'react';
-import { LinkToStacked } from 'react-stacked-pages-hook';
+import { LinkToStacked } from './CustomLinkToStacked';
 import { Link } from 'gatsby';
 import { Styled, jsx, Heading } from 'theme-ui';
 


### PR DESCRIPTION
This change preserves the following,
- ⌘ + left click to open in new tabs for MacOS
- Ctrl + left click to open in new tabs for other OS

Key points,
- Override LinkToStacked of `react-stacked-pages-hook` with appropriate logic. 
- Using `window.open` to open `to` relative links in new tab.
- Using `window.navigator.platform` to detect OS platform.

Fixes #14 